### PR TITLE
Devel

### DIFF
--- a/dardel/config.yaml
+++ b/dardel/config.yaml
@@ -50,6 +50,8 @@ set-resources:
     runtime: 30
     mem_mb: 8880
   # common.smk
+  filter_seqs:
+    mem_mb: 17760
   vsearch_align:
     mem_mb: 8880
   # qiime2.smk

--- a/pixi.lock
+++ b/pixi.lock
@@ -922,7 +922,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.35.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.6.2-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.5.0-hdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-1.4.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-jobstep-0.3.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.19.4-pyhdfd78af_0.tar.bz2
@@ -930,7 +930,7 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-1.2.3-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.1.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.2.1-pyhdfd78af_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.6.2-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.5.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -1177,7 +1177,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.35.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.6.2-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.5.0-hdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-1.4.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-jobstep-0.3.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.19.4-pyhdfd78af_0.tar.bz2
@@ -1185,7 +1185,7 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-1.2.3-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.1.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.2.1-pyhdfd78af_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.6.2-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.5.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h68829e0_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -1436,7 +1436,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.35.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.6.2-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.5.0-hdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-1.4.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-jobstep-0.3.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.19.4-pyhdfd78af_0.tar.bz2
@@ -1444,7 +1444,7 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-1.2.3-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.1.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.2.1-pyhdfd78af_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.6.2-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.5.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -1687,7 +1687,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.35.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.6.2-hdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.5.0-hdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-1.4.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-jobstep-0.3.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.19.4-pyhdfd78af_0.tar.bz2
@@ -1695,7 +1695,7 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-1.2.3-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.1.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.2.1-pyhdfd78af_0.tar.bz2
-      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.6.2-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.5.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -16912,20 +16912,20 @@ packages:
   license_family: BSD
   size: 26051
   timestamp: 1739781801801
-- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.6.2-hdfd78af_0.tar.bz2
-  sha256: 9ef254e85aecaa44711e939a3e2c0a7dbf13495499e44cda0c02eb1d491a8751
-  md5: 77913d7ffc1eeb11e07617679dd568bb
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.5.0-hdfd78af_0.tar.bz2
+  sha256: d56c9fc384ac62df3857358f3c342bfa10011652200704b75d7008ffb3898055
+  md5: b2b10a4695be9cca8c30225ed47d2d0e
   depends:
   - eido
   - pandas
   - peppy
   - pygments
   - slack_sdk
-  - snakemake-minimal 9.6.2.*
+  - snakemake-minimal 9.5.0.*
   license: MIT
   license_family: MIT
-  size: 9370
-  timestamp: 1750757164887
+  size: 9385
+  timestamp: 1747909014416
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-1.4.0-pyhdfd78af_0.tar.bz2
   sha256: d722b0eb30cb4146219b3df659ce38ee7e97b4c6109268ec40a9a1c2d4016c9d
   md5: 395cccfe8cc1841f6ae9852de7dfa385
@@ -17003,9 +17003,9 @@ packages:
   license_family: MIT
   size: 19926
   timestamp: 1742480267140
-- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.6.2-pyhdfd78af_0.tar.bz2
-  sha256: 02b77c75df45c004d04aef9ee23a8d84f7a1fc9cf1e6734492696d7678c8c0c0
-  md5: aa88acccf6bd0c9b4e156ebaa5ee6437
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.5.0-pyhdfd78af_0.tar.bz2
+  sha256: ac7bad2b2f2332e79659ee537e04e38837cfefbed32cd5970b9b1193bce5cb0d
+  md5: 5999d1a3c5836af02c2696c6f780802a
   depends:
   - appdirs
   - conda-inject >=1.3.1,<2.0
@@ -17038,8 +17038,8 @@ packages:
   - yte >=1.5.5,<2.0
   license: MIT
   license_family: MIT
-  size: 875635
-  timestamp: 1750757163506
+  size: 868720
+  timestamp: 1747909013046
 - conda: https://conda.anaconda.org/bioconda/linux-64/sra-tools-3.2.1-h4304569_1.tar.bz2
   sha256: 607b43e8f5b0c9e0e7228bbe19d3d50a6dc54d4b072b0ed508081fe468604264
   md5: e25d29bf7be97231d3d01fedeb7e01c0

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,7 @@ platforms = ["linux-64", "osx-64", "linux-aarch64", "osx-arm64"]
 linux = "3.10.0"
 
 [feature.happ]
-dependencies = { python = "*", snakemake = "*", scikit-learn = "*", biopython = "*", tqdm = "*", polars = "*", pandas = "*", seqkit = "*", conda = "*", r-ape = "*", 'r-data.table' = "*", snakemake-executor-plugin-slurm = "*", pigz = "*" }
+dependencies = { python = "*", snakemake = "<9.5.1", scikit-learn = "*", biopython = "*", tqdm = "*", polars = "*", pandas = "*", seqkit = "*", conda = "*", r-ape = "*", 'r-data.table' = "*", snakemake-executor-plugin-slurm = "*", pigz = "*" }
 
 [feature.blastn]
 dependencies = { blast = "*" }

--- a/slurm/config.yaml
+++ b/slurm/config.yaml
@@ -52,6 +52,8 @@ set-resources:
     runtime: 30
     mem_mb: 8880
   # common.smk
+  filter_seqs:
+    mem_mb: 17760
   vsearch_align:
     mem_mb: 8880
   # qiime2.smk

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -442,7 +442,7 @@ def get_rank_settings(config):
     elif config["taxonomy_source"] == "epa-ng":
         return "--ranks " + " ".join(config["epa-ng"]["tree_ranks"])
     elif config["taxonomy_source"] == "vsearch":
-        if os.path.exists(config["qiime2"]["ref"]) and os.path.exists(config["qiime"]["taxfile"]):
+        if os.path.exists(config["qiime2"]["ref"]) and os.path.exists(config["qiime2"]["taxfile"]):
             return "--ranks " + " ".join(config["qiime2"]["ranks"])
         else:
             if os.path.exists(config["sintax"]["ref"]):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,6 +1,3 @@
-localrules:
-    filter_seqs,
-
 def get_input_fasta(wildcards):
     """
     Determine the input fasta file for the dataset

--- a/workflow/rules/qiime2.smk
+++ b/workflow/rules/qiime2.smk
@@ -184,7 +184,7 @@ rule qiime2_classify_vsearch:
     shell:
         """
         qiime feature-classifier classify-consensus-vsearch --i-reference-reads {input.ref} --i-query {input.qry} \
-            --i-reference-taxonomy {input.ref_tax} --o-classification {output.vsearch} --o-search-results {output.hits} \
+            --i-reference-taxonomy {input.ref_tax} --p-maxrejects 32 --o-classification {output.vsearch} --o-search-results {output.hits} \
             --p-threads {threads} --verbose > {log} 2>&1
         """
 


### PR DESCRIPTION
This pull request introduces several updates to resource configurations, dependency management, and workflow logic to improve performance and compatibility. The most important changes include increasing memory allocation for the `filter_seqs` step, restricting the `snakemake` version for better stability, fixing a configuration reference bug, and optimizing the `qiime2_classify_vsearch` rule. Below are the key changes grouped by theme:

**Resource Configuration Updates:**
* Removed the `localrules: filter_seqs,` line from `workflow/rules/common.smk` and Increased memory allocation for the `filter_seqs` step in both `dardel/config.yaml` and `slurm/config.yaml` to 17760 MB, which should help with processing larger datasets. [[1]](diffhunk://#diff-e45399c210316b9c3d93f7b2da565a8d607a4e2388afcd4e6de29b2cb467cf76R53-R54) [[2]](diffhunk://#diff-fc113d94441fbca45c37b94b9d898deeff709faa284c905d44b11100af982e64R55-R56)

**Dependency Management:**
* Restricted the `snakemake` dependency to versions below 9.5.1 in `pixi.toml` to avoid compatibility issues with recent updates.

**Workflow Logic Improvements:**
* Fixed a bug in `workflow/Snakefile` by correcting the reference from `config["qiime"]["taxfile"]` to `config["qiime2"]["taxfile"]` for the vsearch taxonomy source, ensuring the correct configuration is used.
* Added the `--p-maxrejects 32` parameter to the `qiime2_classify_vsearch` rule in `workflow/rules/qiime2.smk` to optimize classification performance.