### PR TITLE
Devel

### DIFF
--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -2,25 +2,40 @@ localrules:
     filter_codons,
     filter_length,
 
+
 rule filter_length:
     """
     Filter ASVs by length.
     """
-    message: f"Filtering input sequences to {config['preprocessing']['min_length']}-{config['preprocessing']['max_length']} bp"
+    message:
+        f"Filtering input sequences to {config['preprocessing']['min_length']}-{config['preprocessing']['max_length']} bp"
     output:
-        fasta=ensure("results/preprocess/{rundir}/ASV_length_filtered.fna", non_empty=True),
-        counts=ensure("results/preprocess/{rundir}/ASV_length_filtered.table.tsv", non_empty=True)
+        fasta=ensure(
+            "results/preprocess/{rundir}/ASV_length_filtered.fna", non_empty=True
+        ),
+        counts=ensure(
+            "results/preprocess/{rundir}/ASV_length_filtered.table.tsv", non_empty=True
+        ),
     input:
         fasta="data/{rundir}/asv_seqs.fasta",
-        counts="data/{rundir}/asv_counts.tsv"
+        counts="data/{rundir}/asv_counts.tsv",
     log:
-        "logs/preprocess/{rundir}/filter_length.log"
+        "logs/preprocess/{rundir}/filter_length.log",
     params:
-        min_length=lambda wildcards: f"-m {config['preprocessing']['min_length']}" if config['preprocessing']["min_length"] else "",
-        max_length=lambda wildcards: f"-M {config['preprocessing']['max_length']}" if config['preprocessing']["max_length"] else "",
+        min_length=lambda wildcards: (
+            f"-m {config['preprocessing']['min_length']}"
+            if config["preprocessing"]["min_length"]
+            else ""
+        ),
+        max_length=lambda wildcards: (
+            f"-M {config['preprocessing']['max_length']}"
+            if config["preprocessing"]["max_length"]
+            else ""
+        ),
         outdir=lambda wildcards, output: os.path.dirname(output["fasta"]),
-        src=workflow.source_path("../scripts/filt_length.py")
-    shadow: "minimal"
+        src=workflow.source_path("../scripts/filt_length.py"),
+    shadow:
+        "minimal"
     shell:
         """
         python {params.src} -f {input.fasta} -t {input.counts} -p ASV_length {params.min_length} {params.max_length} > {log} 2>&1
@@ -28,30 +43,49 @@ rule filter_length:
         mv ASV_length_filtered.table.tsv {output.counts}
         """
 
+
 rule filter_codons:
     """
     Filter ASVs with in-frame stop codons.
     """
-    message: "Removing sequences with in-frame stop codons"
+    message:
+        "Removing sequences with in-frame stop codons"
     output:
-        fasta=ensure("results/preprocess/{rundir}/ASV_codon_filtered.fna", non_empty=True),
-        counts=ensure("results/preprocess/{rundir}/ASV_codon_filtered.table.tsv", non_empty=True),
-        l="results/preprocess/{rundir}/ASV_codon_filtered.list"
+        fasta=ensure(
+            "results/preprocess/{rundir}/ASV_codon_filtered.fna", non_empty=True
+        ),
+        counts=ensure(
+            "results/preprocess/{rundir}/ASV_codon_filtered.table.tsv", non_empty=True
+        ),
+        l="results/preprocess/{rundir}/ASV_codon_filtered.list",
     input:
-        fasta=lambda wildcards: rules.filter_length.output.fasta if config["preprocessing"]["filter_length"] else f"data/{wildcards.rundir}/asv_seqs.fasta",
-        counts=lambda wildcards: rules.filter_length.output.counts if config["preprocessing"]["filter_length"] else f"data/{wildcards.rundir}/asv_counts.tsv"
+        fasta=lambda wildcards: (
+            rules.filter_length.output.fasta
+            if config["preprocessing"]["filter_length"]
+            else f"data/{wildcards.rundir}/asv_seqs.fasta"
+        ),
+        counts=lambda wildcards: (
+            rules.filter_length.output.counts
+            if config["preprocessing"]["filter_length"]
+            else f"data/{wildcards.rundir}/asv_counts.tsv"
+        ),
     log:
-        "logs/preprocess/{rundir}/filter_codons.log"
+        "logs/preprocess/{rundir}/filter_codons.log",
     params:
-        stop_codons=config['preprocessing']["stop_codons"],
-        start_position=config['preprocessing']["start_position"],
-        end_position=lambda wildcards: f"-e {config['preprocessing']['end_position']}" if config['preprocessing']['end_position']>0 else "",
+        stop_codons=config["preprocessing"]["stop_codons"],
+        start_position=config["preprocessing"]["start_position"],
+        end_position=lambda wildcards: (
+            f"-e {config['preprocessing']['end_position']}"
+            if config["preprocessing"]["end_position"] > 0
+            else ""
+        ),
         outdir=lambda wildcards, output: os.path.dirname(output["fasta"]),
-        src=workflow.source_path("../scripts/filt_codons.py")
-    shadow: "minimal"
+        src=workflow.source_path("../scripts/filt_codons.py"),
+    shadow:
+        "minimal"
     shell:
         """
-        python {params.src} -f {input.fasta} -t {input.counts} -p ASV_codon -x {params.stop_codons} -s {params.start_position} {params.end_position} > {log} 2>&1
+        python {params.src} -f {input.fasta} -t {input.counts} -p ASV_codon -x {params.stop_codons} -s {params.start_position} -e {params.end_position} > {log} 2>&1
         mv ASV_codon_filtered.fna {output.fasta}
         mv ASV_codon_filtered.table.tsv {output.counts}
         mv ASV_codon_filtered.list {output.l}

--- a/workflow/scripts/filt_codons.py
+++ b/workflow/scripts/filt_codons.py
@@ -53,7 +53,7 @@ parser.add_argument(
     type=int,
     help="Specific position of the ASV where to start checking for codons. By default it starts from position 1",
     required=False,
-    default=0,
+    default=1,
 )
 
 parser.add_argument(


### PR DESCRIPTION
This pull request refactors the preprocessing workflow for ASV filtering in the `workflow/rules/preprocess.smk` file and updates the default start position for codon filtering in `workflow/scripts/filt_codons.py`. The main focus is on improving code readability and maintainability by reformatting rule definitions and clarifying parameter handling.

**Workflow rule formatting and parameter handling:**

* Reformatted the `filter_length` and `filter_codons` rules in `preprocess.smk` for improved readability, including multi-line formatting for `message`, `output`, `input`, `log`, and `params` sections.
* Updated lambda expressions in `params` to use multi-line formatting and clarified conditional logic for `min_length`, `max_length`, and `end_position` parameters.

**Codon filtering logic update:**

* Changed the default value for the `--start_position` argument in `filt_codons.py` from 0 to 1, making the start position more biologically intuitive.